### PR TITLE
fix #28

### DIFF
--- a/classes/factory/category.php
+++ b/classes/factory/category.php
@@ -64,7 +64,7 @@ class category {
      * @return int
      * @throws moodle_exception
      */
-    public static function create(string $name, string $idnumber, string $description = ''): int {
+    public static function create(string $name, ?string $idnumber, string $description = ''): int {
         $record = new stdClass();
         $record->name = $name;
         $record->description = $description;


### PR DESCRIPTION
Updating `category::create` to being able to receive null idnumbers.  Moodle's core function `core_course_category::create` already handle null idnumbers.