### PR TITLE
Closes Issue #48. Removed deprecated code

### DIFF
--- a/classes/coursetransfer_backup.php
+++ b/classes/coursetransfer_backup.php
@@ -110,7 +110,6 @@ class coursetransfer_backup {
         $bc->set_execution(backup::EXECUTION_DELAYED);
         $bc->save_controller();
         $asynctask = new create_backup_course_task();
-        $asynctask->set_blocking(false);
         if (!is_null($nextruntime)) {
             $asynctask->set_next_run_time($nextruntime);
         }

--- a/classes/coursetransfer_download.php
+++ b/classes/coursetransfer_download.php
@@ -77,7 +77,6 @@ class coursetransfer_download {
      */
     public static function create_task_download_course(stdClass $request, string $fileurl): bool {
         $asynctask = new download_file_course_task();
-        $asynctask->set_blocking(false);
         $asynctask->set_custom_data(
                 ['requestid' => $request->id, 'fileurl' => $fileurl]
         );

--- a/classes/coursetransfer_remove.php
+++ b/classes/coursetransfer_remove.php
@@ -69,7 +69,6 @@ class coursetransfer_remove {
             int $requestoriginid, int $requestdestid, int $courseid,
             stdClass $destsite, int $userid, int $nextruntime = null): bool {
         $resasynctask = new remove_course_task();
-        $resasynctask->set_blocking(false);
         $payload = [
                 'targetsiteid' => $destsite->id,
                 'courseid' => $courseid,
@@ -98,7 +97,6 @@ class coursetransfer_remove {
     public static function create_task_remove_category(
             int $requestoriginid, int $requestdestid, int $catid, stdClass $destsite, int $userid, int $nextruntime = null): bool {
         $resasynctask = new remove_category_task();
-        $resasynctask->set_blocking(false);
         $payload = [
                 'targetsiteid' => $destsite->id,
                 'catid' => $catid,
@@ -121,7 +119,6 @@ class coursetransfer_remove {
      */
     public static function create_cleanup_course_bin_task(stdClass $course): bool {
         $resasynctask = new cleanup_course_bin_task();
-        $resasynctask->set_blocking(false);
         $payload = [
                 'courseid' => $course->id,
                 'shortname' => $course->shortname,
@@ -139,7 +136,6 @@ class coursetransfer_remove {
      */
     public static function create_cleanup_category_bin_task(int $catid): bool {
         $resasynctask = new cleanup_category_bin_task();
-        $resasynctask->set_blocking(false);
         $payload = [
                 'categoryid' => $catid,
         ];

--- a/classes/coursetransfer_restore.php
+++ b/classes/coursetransfer_restore.php
@@ -77,7 +77,6 @@ class coursetransfer_restore {
      */
     public static function create_task_restore_course(stdClass $request, stored_file $file): bool {
         $resasynctask = new restore_course_task();
-        $resasynctask->set_blocking(false);
         $resasynctask->set_custom_data(
                 ['requestid' => $request->id, 'fileid' => $file->get_id()]
         );

--- a/classes/privacy/provider.php
+++ b/classes/privacy/provider.php
@@ -63,6 +63,18 @@ class provider implements
      * @return collection the updated collection of metadata items.
      */
     public static function get_metadata(collection $collection) : collection {
+        $collection->add_database_table('local_coursetransfer_request', [
+            'userid' => 'privacy:metadata:local_coursetransfer_request:userid',
+        ], 'privacy:metadata:local_coursetransfer_request');
+
+        $collection->add_database_table('local_coursetransfer_origin', [
+            'userid' => 'privacy:metadata:local_coursetransfer_origin:userid',
+        ], 'privacy:metadata:local_coursetransfer_origin');
+
+        $collection->add_database_table('local_coursetransfer_target', [
+            'userid' => 'privacy:metadata:local_coursetransfer_target:userid',
+        ], 'privacy:metadata:local_coursetransfer_target');
+
         return $collection;
     }
 

--- a/lang/en/local_coursetransfer.php
+++ b/lang/en/local_coursetransfer.php
@@ -34,6 +34,12 @@
 
 $string['pluginname'] = 'Course Transfer';
 $string['pluginname_header_general'] = 'General';
+$string['privacy:metadata:local_coursetransfer_request:userid'] = 'Creator User ID';
+$string['privacy:metadata:local_coursetransfer_request'] = 'Table that contains the information of the requests made';
+$string['privacy:metadata:local_coursetransfer_origin:userid'] = 'User ID last modified';
+$string['privacy:metadata:local_coursetransfer_origin'] = 'Table of Origin Sites available';
+$string['privacy:metadata:local_coursetransfer_target:userid'] = 'User ID last modified';
+$string['privacy:metadata:local_coursetransfer_target'] = 'Table of Target Sites availables';
 $string['setting_target_restore_course_max_size'] = 'Maximum course size to be restored (MB)';
 $string['setting_target_restore_course_max_size_desc'] = 'Limit of the size of the backup copy (MBZ file)of the origin course to be restored in MB.';
 $string['setting_target_sites'] = 'Target sites';

--- a/tests/coursetransfer_restore_course_merge_test.php
+++ b/tests/coursetransfer_restore_course_merge_test.php
@@ -61,6 +61,7 @@ use phpunit_util;
 use stdClass;
 use stored_file;
 use testing_data_generator;
+use \core\cron;
 
 defined('MOODLE_INTERNAL') || die();
 
@@ -68,7 +69,6 @@ global $CFG;
 require_once($CFG->dirroot . '/webservice/tests/helpers.php');
 require_once($CFG->libdir . '/filelib.php');
 require_once($CFG->libdir . '/setuplib.php');
-require_once($CFG->libdir . '/cronlib.php');
 
 /**
  * coursetransfer_restore_course_test
@@ -79,6 +79,7 @@ require_once($CFG->libdir . '/cronlib.php');
  * @author     3IPUNT <contacte@tresipunt.com>
  * @group      local_coursetransfer
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ * @runTestsInSeparateProcesses
  */
 class coursetransfer_restore_course_merge_test extends advanced_testcase {
 

--- a/tests/coursetransfer_restore_course_test.php
+++ b/tests/coursetransfer_restore_course_test.php
@@ -61,6 +61,7 @@ use phpunit_util;
 use stdClass;
 use stored_file;
 use testing_data_generator;
+use \core\cron;
 
 defined('MOODLE_INTERNAL') || die();
 
@@ -68,7 +69,6 @@ global $CFG;
 require_once($CFG->dirroot . '/webservice/tests/helpers.php');
 require_once($CFG->libdir . '/filelib.php');
 require_once($CFG->libdir . '/setuplib.php');
-require_once($CFG->libdir . '/cronlib.php');
 
 /**
  * coursetransfer_restore_course_test
@@ -79,6 +79,7 @@ require_once($CFG->libdir . '/cronlib.php');
  * @author     3IPUNT <contacte@tresipunt.com>
  * @group      local_coursetransfer
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ * @runTestsInSeparateProcesses
  */
 class coursetransfer_restore_course_test extends advanced_testcase {
 
@@ -288,7 +289,7 @@ class coursetransfer_restore_course_test extends advanced_testcase {
         $this->group3 = $this->getDataGenerator()->create_group(['courseid' => $this->targetcourse3->id]);
         groups_add_member($this->group3, $student4);
 
-        $this->group4 = $this->getDataGenerator()->create_group(['courseid' => $this->targetcourse2->id]);
+        $this->group4 = $this->getDataGenerator()->create_group(['courseid' => $this->targetcourse3->id]);
         groups_add_member($this->group4, $student5);
         groups_add_member($this->group4, $student6);
 
@@ -679,7 +680,7 @@ class coursetransfer_restore_course_test extends advanced_testcase {
                 $this->assertEquals('SuperHeroes Summary', $section->summary);
                 $mods = 0;
                 foreach ($cms as $cm) {
-                    if ($cm->section === $section->id) {
+                    if ($cm->section == $section->id) {
                         $mods ++;
                     }
                 }
@@ -690,7 +691,7 @@ class coursetransfer_restore_course_test extends advanced_testcase {
                 $this->assertEquals('Cars Summary', $section->summary);
                 $mods = 0;
                 foreach ($cms as $cm) {
-                    if ($cm->section === $section->id) {
+                    if ($cm->section == $section->id) {
                         $mods ++;
                     }
                 }


### PR DESCRIPTION
Closes Issue https://github.com/UNIMOODLE/moodle-local_coursetransfer/issues/48.

Resolves the issues with unit testing.

NOTE: This error only affects sites using Moodle 4.4 and above. Consider creating a new branch MOODLE_404_STABLE with the changes in this PR. Older versions of Moodle will not produce the same error, the main branch can be kept separate as is.

How to replicate:

1. Deploy local Moodle instance (4.4 or higher) and install local_coursetransfer plugin
2. Initialize PHPUnit testing environment
3. Run vendor/bin/phpunit local/coursetransfer/tests/course_transfer_restore_course_merge_test.php and vendor/bin/phpunit local/coursetransfer/tests/course_transfer_restore_course_test.php
4. Apply changes from branch
5. Re-run tests to verify successful output.

The correct implementation of the privacy provider has been included with this PR.

I found some additional tests failing after implementing the changes related to the cron library, and deprecated `set_blocking()` function.

Error logs:
```
local_coursetransfer\coursetransfer_restore_course_test::tests_restore_course
Failed asserting that actual size 3 matches expected size 2.

/var/www/saylor/local/coursetransfer/tests/coursetransfer_restore_course_test.php:737
/var/www/saylor/local/coursetransfer/tests/coursetransfer_restore_course_test.php:440
/var/www/saylor/lib/phpunit/classes/advanced_testcase.php:76
```

```
local_coursetransfer\coursetransfer_restore_course_test::tests_restore_course
Failed asserting that 0 matches expected 2.

/var/www/saylor/local/coursetransfer/tests/coursetransfer_restore_course_test.php:701
/var/www/saylor/local/coursetransfer/tests/coursetransfer_restore_course_test.php:434
/var/www/saylor/lib/phpunit/classes/advanced_testcase.php:76
```

I added fixes for these issues to the PR as well. Hope this helps, thank you!

Best regards,
Niko
