### PR TITLE
Closes Issue #50. Updated external function params to fix failing unit tests

### DIFF
--- a/classes/external/backend/origin_category_external.php
+++ b/classes/external/backend/origin_category_external.php
@@ -165,7 +165,7 @@ class origin_category_external extends external_api {
                     [
                         'code' => new external_value(PARAM_TEXT, 'Code'),
                         'msg' => new external_value(PARAM_TEXT, 'Message'),
-                    ], PARAM_TEXT, 'Errors'
+                    ], PARAM_TEXT,  VALUE_REQUIRED, 'Errors',
                 )),
                 'paging' => new external_single_structure([
                     'totalcount' => new external_value(PARAM_INT, 'Total number of courses', VALUE_OPTIONAL),
@@ -182,7 +182,7 @@ class origin_category_external extends external_api {
                         'totalcourses' => new external_value(PARAM_INT, 'Total courses', VALUE_OPTIONAL),
                         'totalsubcategories' => new external_value(PARAM_INT, 'Total subcategories', VALUE_OPTIONAL),
                         'totalcourseschild' => new external_value(PARAM_INT, 'Total courses all subcategory', VALUE_OPTIONAL),
-                    ], PARAM_TEXT, 'Data'
+                    ], PARAM_TEXT,  VALUE_REQUIRED, 'Data',
                 )),
             ]
         );
@@ -301,7 +301,7 @@ class origin_category_external extends external_api {
                     [
                         'code' => new external_value(PARAM_INT, 'Code'),
                         'msg' => new external_value(PARAM_TEXT, 'Message'),
-                    ], PARAM_TEXT, 'Errors'
+                    ], PARAM_TEXT, VALUE_REQUIRED, 'Errors',
                 )),
                 'data' => new external_single_structure(
                     [

--- a/classes/external/backend/origin_course_backup_external.php
+++ b/classes/external/backend/origin_course_backup_external.php
@@ -267,7 +267,7 @@ class origin_course_backup_external extends external_api {
                     [
                         'code' => new external_value(PARAM_TEXT, 'Code'),
                         'msg' => new external_value(PARAM_TEXT, 'Message'),
-                    ], PARAM_TEXT, 'Errors'
+                    ], PARAM_TEXT, VALUE_REQUIRED, 'Errors', 
                 )),
                 'data' => new external_single_structure(
                     [
@@ -281,7 +281,7 @@ class origin_course_backup_external extends external_api {
                         'course_category_idnumber' => new external_value(PARAM_RAW, 'Category ID Number', VALUE_OPTIONAL),
                         'origin_backup_size_estimated' => new external_value(PARAM_INT,
                             'Backup Size Estimated (MB)', VALUE_OPTIONAL ),
-                    ], PARAM_TEXT, 'Data'
+                    ], PARAM_TEXT, VALUE_REQUIRED, 'Data',
                 ),
             ]
         );

--- a/classes/external/backend/origin_course_external.php
+++ b/classes/external/backend/origin_course_external.php
@@ -167,7 +167,7 @@ class origin_course_external extends external_api {
                     [
                         'code' => new external_value(PARAM_TEXT, 'Code'),
                         'msg' => new external_value(PARAM_TEXT, 'Message'),
-                    ], 'Errors'
+                    ], PARAM_TEXT, VALUE_REQUIRED, 'Errors',
                 )),
                 'paging' => new external_single_structure([
                     'totalcount' => new external_value(PARAM_INT, 'Total number of courses', VALUE_OPTIONAL),
@@ -184,7 +184,7 @@ class origin_course_external extends external_api {
                         'categoryid' => new external_value(PARAM_INT, 'Category ID', VALUE_OPTIONAL),
                         'backupsizeestimated' => new external_value(PARAM_TEXT, 'Backup Size Estimated', VALUE_OPTIONAL),
                         'categoryname' => new external_value(PARAM_TEXT, 'Category Name', VALUE_OPTIONAL),
-                    ], 'Course info'
+                    ], PARAM_TEXT, VALUE_REQUIRED, 'Course info',
                 ), 'Courses info'),
             ]
         );
@@ -290,7 +290,7 @@ class origin_course_external extends external_api {
                     [
                         'code' => new external_value(PARAM_INT, 'Code'),
                         'msg' => new external_value(PARAM_TEXT, 'Message'),
-                    ], PARAM_TEXT, 'Errors'
+                    ], PARAM_TEXT, VALUE_REQUIRED, 'Errors',
                 )),
                 'data' => new external_single_structure(
                     [

--- a/classes/external/backend/origin_user_external.php
+++ b/classes/external/backend/origin_user_external.php
@@ -138,9 +138,7 @@ class origin_user_external extends external_api {
                     [
                         'code' => new external_value(PARAM_TEXT, 'Code'),
                         'msg' => new external_value(PARAM_TEXT, 'Message'),
-                    ],
-                    PARAM_TEXT,
-                    'Errors'
+                    ], PARAM_TEXT, VALUE_REQUIRED, 'Errors', 
                 )),
                 'data' => new external_single_structure(
                     [
@@ -149,9 +147,7 @@ class origin_user_external extends external_api {
                         'firstname' => new external_value(PARAM_TEXT, 'Firstname', VALUE_OPTIONAL),
                         'lastname' => new external_value(PARAM_TEXT, 'Lastname', VALUE_OPTIONAL),
                         'email' => new external_value(PARAM_TEXT, 'Email', VALUE_OPTIONAL),
-                    ],
-                    PARAM_TEXT,
-                    'Data'
+                    ],PARAM_TEXT, VALUE_REQUIRED, 'Data', 
                 ),
             ]
         );

--- a/classes/external/backend/remove_external.php
+++ b/classes/external/backend/remove_external.php
@@ -229,7 +229,7 @@ class remove_external extends external_api {
                         [
                                 'code' => new external_value(PARAM_TEXT, 'Code'),
                                 'msg' => new external_value(PARAM_TEXT, 'Message'),
-                        ], PARAM_TEXT, 'Errors'
+                        ], PARAM_TEXT, VALUE_REQUIRED, 'Errors',
                 )),
                 'data' => new external_single_structure(
                     [
@@ -241,7 +241,7 @@ class remove_external extends external_api {
                         'course_category_id' => new external_value(PARAM_INT, 'Category ID', VALUE_OPTIONAL),
                         'course_category_name' => new external_value(PARAM_RAW, 'Category Name', VALUE_OPTIONAL),
                         'course_category_idnumber' => new external_value(PARAM_RAW, 'Category ID Number', VALUE_OPTIONAL),
-                    ], PARAM_TEXT, 'Data'
+                    ], PARAM_TEXT, VALUE_REQUIRED, 'Data',
                 ),
                 ]
         );
@@ -404,7 +404,7 @@ class remove_external extends external_api {
                                 [
                                         'code' => new external_value(PARAM_TEXT, 'Code'),
                                         'msg' => new external_value(PARAM_TEXT, 'Message'),
-                                ], PARAM_TEXT, 'Errors'
+                                ], PARAM_TEXT, VALUE_REQUIRED, 'Errors'
                         )),
                         'data' => new external_single_structure(
                             [
@@ -413,7 +413,7 @@ class remove_external extends external_api {
                                 'course_category_id' => new external_value(PARAM_INT, 'Category ID', VALUE_OPTIONAL),
                                 'course_category_name' => new external_value(PARAM_RAW, 'Category Name', VALUE_OPTIONAL),
                                 'course_category_idnumber' => new external_value(PARAM_RAW, 'Category ID Number', VALUE_OPTIONAL),
-                            ], PARAM_TEXT, 'Data'
+                            ], PARAM_TEXT, VALUE_REQUIRED, 'Data'
                         ),
                 ]
         );

--- a/classes/external/backend/target_course_callback_external.php
+++ b/classes/external/backend/target_course_callback_external.php
@@ -177,7 +177,7 @@ class target_course_callback_external extends external_api {
                     [
                         'code' => new external_value(PARAM_TEXT, 'Code'),
                         'msg' => new external_value(PARAM_TEXT, 'Message'),
-                    ], PARAM_TEXT, 'Errors'
+                    ], PARAM_TEXT, VALUE_REQUIRED, 'Errors',
                 )),
             ]
         );
@@ -285,7 +285,7 @@ class target_course_callback_external extends external_api {
                     [
                         'code' => new external_value(PARAM_TEXT, 'Code'),
                         'msg' => new external_value(PARAM_TEXT, 'Message'),
-                    ], PARAM_TEXT, 'Errors'
+                    ], PARAM_TEXT, VALUE_REQUIRED, 'Errors',
                 )),
             ]
         );
@@ -404,7 +404,7 @@ class target_course_callback_external extends external_api {
                     [
                         'code' => new external_value(PARAM_INT, 'Code'),
                         'msg' => new external_value(PARAM_TEXT, 'Message'),
-                    ], PARAM_TEXT, 'Errors'
+                    ], PARAM_TEXT, VALUE_REQUIRED, 'Errors',
                 )),
             ]
         );
@@ -518,7 +518,7 @@ class target_course_callback_external extends external_api {
                     [
                         'code' => new external_value(PARAM_INT, 'Code'),
                         'msg' => new external_value(PARAM_TEXT, 'Message'),
-                    ], PARAM_TEXT, 'Errors'
+                    ], PARAM_TEXT, VALUE_REQUIRED, 'Errors',
                 )),
             ]
         );

--- a/classes/external/frontend/sites_external.php
+++ b/classes/external/frontend/sites_external.php
@@ -601,7 +601,7 @@ class sites_external extends external_api {
                         [
                             'code' => new external_value(PARAM_TEXT, 'Code'),
                             'msg' => new external_value(PARAM_TEXT, 'Message'),
-                        ], PARAM_TEXT, 'Errors'
+                        ], PARAM_TEXT, VALUE_REQUIRED, 'Errors',
                 )),
             ]
         );
@@ -682,7 +682,7 @@ class sites_external extends external_api {
                     [
                         'code' => new external_value(PARAM_TEXT, 'Code'),
                         'msg' => new external_value(PARAM_TEXT, 'Message'),
-                    ], PARAM_TEXT, 'Errors'
+                    ], PARAM_TEXT, VALUE_REQUIRED, 'Errors',
                 )),
             ]
         );


### PR DESCRIPTION
Closes Issue https://github.com/UNIMOODLE/moodle-local_coursetransfer/issues/50.

Resolves the issues with unit testing.

How to replicate:

1. Deploy local Moodle instance (4.5) and install `local_coursetransfer` plugin
2. Initialize PHPUnit testing environment
3. Run `vendor/bin/phpunit lib/external/tests/external_api_test.php`
4. Apply changes from branch
5. Re-run tests to verify successful output.
