### PR TITLE
Fix: add missing coursetransfer:view_logs capability string

### DIFF
--- a/lang/cat/local_coursetransfer.php
+++ b/lang/cat/local_coursetransfer.php
@@ -331,3 +331,4 @@ $string['select_category_target'] = 'Seleccioneu la categoria on es restaurarà 
 $string['select_destination'] = 'Seleccioneu la destinació';
 $string['search_course_destination'] = 'Cerca el curs de destinació';
 $string['not_course_found'] = "No s'ha trobat cap curs...";
+$string['coursetransfer:view_logs'] = 'Veure registres';

--- a/lang/en/local_coursetransfer.php
+++ b/lang/en/local_coursetransfer.php
@@ -331,3 +331,4 @@ $string['select_category_target'] = 'Select the category where the new course wi
 $string['select_destination'] = 'Select the destination';
 $string['search_course_destination'] = 'Search the destination course';
 $string['not_course_found'] = 'No course found...';
+$string['coursetransfer:view_logs'] = 'View logs';

--- a/lang/es/local_coursetransfer.php
+++ b/lang/es/local_coursetransfer.php
@@ -333,3 +333,4 @@ $string['select_category_target'] = 'Seleccione la categoría donde se restaurar
 $string['select_destination'] = 'Seleccione el destino';
 $string['search_course_destination'] = 'Busca el curso de destino';
 $string['not_course_found'] = 'No se ha encontrado ningún curso...';
+$string['coursetransfer:view_logs'] = 'Ver registros';

--- a/lang/eu/local_coursetransfer.php
+++ b/lang/eu/local_coursetransfer.php
@@ -331,3 +331,4 @@ $string['select_category_target'] = 'Hautatu ikastaro berria berreskuratuko den 
 $string['select_destination'] = 'Hautatu helmuga';
 $string['search_course_destination'] = 'Aurkitu helmuga ikastaroa';
 $string['not_course_found'] = 'Ez da ikastarorik aurkitu...';
+$string['coursetransfer:view_logs'] = 'Erregistroak ikusi';

--- a/lang/gl/local_coursetransfer.php
+++ b/lang/gl/local_coursetransfer.php
@@ -331,3 +331,4 @@ $string['select_category_target'] = 'Seleccione a categoría onde se restaurará
 $string['select_destination'] = 'Seleccione o destino';
 $string['search_course_destination'] = 'Busca o curso de destino';
 $string['not_course_found'] = "Non se atopou ningún curso...";
+$string['coursetransfer:view_logs'] = 'Ver rexistros';

--- a/version.php
+++ b/version.php
@@ -33,7 +33,7 @@
  */
 defined('MOODLE_INTERNAL') || die;
 
-$plugin->version   = 2024061800;
+$plugin->version   = 2024061801;
 $plugin->requires  = 2021051703;
 $plugin->component = 'local_coursetransfer';
 $plugin->release   = '1.1.1';


### PR DESCRIPTION
This patch adds the missing language string:

    $string['coursetransfer:view_logs'];

Without this string, Moodle throws:
"Invalid get_string() identifier: 'coursetransfer:view_logs'"

This happens when viewing capability tables in /admin/roles/define.php.

The fix aligns the lang file with the capabilities declared in db/access.php.